### PR TITLE
Changing parameters in json to revert to fileManager if not there, and allow 4 params on solvers to change on restart

### DIFF
--- a/build/build_scripts/build.sh
+++ b/build/build_scripts/build.sh
@@ -15,8 +15,8 @@
 
 
 # If a library cannot be found by Cmake, you can specify the path like so:
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:/u1/kck540/Projects/hydrology/Summa-Actors/utils/dependencies/caf/"
-export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:/u1/kck540/Projects/hydrology/Summa-Actors/utils/dependencies/sundials/"
+export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$HOME/Summa-Actors/utils/dependencies/caf/"
+export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:$HOME/Summa-Actors/utils/dependencies/sundials/"
 
 
 # -----------------------------------

--- a/build/build_scripts/build.sh
+++ b/build/build_scripts/build.sh
@@ -36,5 +36,5 @@ export CMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH:/u1/kck540/Projects/hydrology/Summa
 # If compiling V4 with sundials use the folowing (default)
 # -----------------------------------
 
-cmake -B ./cmake_build -S .. -DUSE_SUNDIALS=ON -DCMAKE_BUILD_TYPE=Debug
+cmake -B ./cmake_build -S .. -DUSE_SUNDIALS=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build ./cmake_build --target all -j

--- a/build/includes/file_access_actor/summa_init_struc.hpp
+++ b/build/includes/file_access_actor/summa_init_struc.hpp
@@ -4,7 +4,7 @@ extern "C" {
   void f_allocate(int& num_gru, int& err, void* message);
   void f_paramSetup(int& err, void* message);
   void f_readRestart(int& err, void* message);
-  void f_getInitTolerance(double& rtol, double& atol);
+  void f_getInitBEStepsIDATol(int& beSteps, double& rtol, double& atolWat, double& atolNrg);
   void f_deallocateInitStruc();
 }
 
@@ -16,6 +16,6 @@ class SummaInitStruc {
     int allocate(int num_gru); // allocate space in Fortran
     int summa_paramSetup();    // call summa_paramSetup
     int summa_readRestart();   // call summa_readRestart
-    void getInitTolerance(double rel_tol, double abs_tol); 
+    void getInitBEStepsIDATol(int be_steps, double rel_tol, double abs_tolWat, double abs_tolNrg); 
 };
 

--- a/build/includes/global/logger.hpp
+++ b/build/includes/global/logger.hpp
@@ -28,8 +28,8 @@ class ErrorLogger {
   public:
     ErrorLogger(const std::string error_log_file_name = "");
     ~ErrorLogger() {};
-    void logError(int ref_gru, int indx_gru, int timestep, double rel_tol, 
-                  double abs_tol, int err_code, const std::string &message);
+    void logError(int ref_gru, int indx_gru, int timestep, int be_steps, double rel_tol, 
+                  double abs_tolWat, double abs_tolNrg, int err_code, const std::string &message);
     void nextAttempt();
 };
 
@@ -43,6 +43,6 @@ class SuccessLogger {
   public:
     SuccessLogger(const std::string success_log_file_name = "");
     ~SuccessLogger() {};
-    void logSuccess(int ref_gru, int indx_gru, double rel_tol, double abs_tol);
+    void logSuccess(int ref_gru, int indx_gru, int be_steps, double rel_tol, double abs_tolWat, double abs_tolNrg);
     void nextAttempt();
 };

--- a/build/includes/global/settings_functions.hpp
+++ b/build/includes/global/settings_functions.hpp
@@ -180,21 +180,24 @@ class HRUActorSettings {
     bool print_output_;
     int output_frequency_;
 
-    double abs_tol_;
+    double abs_tolWat_;
+    double abs_tolNrg_;    
     double rel_tol_;
 
     HRUActorSettings(bool print_output = false, int output_frequency = 100,
-        double abs_tol = 0.0, double rel_tol = 0.0) 
+        double abs_tolWat = 0.0, double abs_tolNrg = 0.0, double rel_tol = 0.0, int be_steps = 0) 
         : print_output_(print_output), output_frequency_(output_frequency), 
-        abs_tol_(abs_tol), rel_tol_(rel_tol)  {};
+        abs_tolWat_(abs_tolWat), abs_tolNrg_(abs_tolNrg), rel_tol_(rel_tol), be_steps_(be_steps)  {};
     ~HRUActorSettings() {};
 
     std::string toString() {
       std::string str = "HRU Actor Settings:\n";
       str += "Print Output: " + std::to_string(print_output_) + "\n";
       str += "Output Frequency: " + std::to_string(output_frequency_) + "\n";
-      str += "Abs Tol: " + std::to_string(abs_tol_) + "\n";
+      str += "Abs Tol Water: " + std::to_string(abs_tolWat_) + "\n";
+      str += "Abs Tol Energy: " + std::to_string(abs_tolNrg_) + "\n";
       str += "Rel Tol: " + std::to_string(rel_tol_) + "\n";
+      str += "BE Steps: " + std::to_string(be_steps_) + "\n";
       return str;
     }
 
@@ -203,8 +206,10 @@ class HRUActorSettings {
       return insp.object(settings).fields(
              insp.field("print_output",     settings.print_output_),
              insp.field("output_frequency", settings.output_frequency_),
-             insp.field("abs_tol",          settings.abs_tol_),
+             insp.field("abs_tolWat",       settings.abs_tolWat_),
+             insp.field("abs_tolNrg",       settings.abs_tolNrg_),
              insp.field("rel_tol",          settings.rel_tol_));
+             insp.field("be_steps",         settings.be_steps_);
     }
 };
 

--- a/build/includes/global/settings_functions.hpp
+++ b/build/includes/global/settings_functions.hpp
@@ -183,6 +183,7 @@ class HRUActorSettings {
     double abs_tolWat_;
     double abs_tolNrg_;    
     double rel_tol_;
+    int be_steps_;
 
     HRUActorSettings(bool print_output = false, int output_frequency = 100,
         double abs_tolWat = 0.0, double abs_tolNrg = 0.0, double rel_tol = 0.0, int be_steps = 0) 

--- a/build/includes/gru_actor/gru_actor.hpp
+++ b/build/includes/gru_actor/gru_actor.hpp
@@ -22,7 +22,7 @@ extern "C" {
       int& dt_init_factor, int& err, void* message);
   void writeGRUOutput_fortran(int& index_gru, int& timestep, int& output_step, 
       void* gru_data, int& err, void* message);
-  void f_setGruTolerances(void* gru_data, double& rel_tol, double& abs_tol);
+  void f_setGruTolerances(void* gru_data, int& be_steps, double& rel_tol, double& abs_tolWat, double& abs_tolNrg);
 }
 
 struct GruDeleter {

--- a/build/includes/gru_actor/gru_data_structure.hpp
+++ b/build/includes/gru_actor/gru_data_structure.hpp
@@ -16,8 +16,10 @@ struct HRU {
   int output_structure_step_index;
 
   // Sundials variables
+  int beSteps;
   double rtol;
-  double atol;
+  double atolWat;
+  double atolNrg;
 
   // HRU data structures
   // Statistic Structure
@@ -76,8 +78,10 @@ bool inspect(Inspector& inspector, HRU& hru_data) {
          inspector.field("dt_init_factor", hru_data.dt_init_factor),
          inspector.field("output_structure_step_index", 
                          hru_data.output_structure_step_index),
+         inspector.field("beSteps", hru_data.beSteps),
          inspector.field("rtol", hru_data.rtol),
-         inspector.field("atol", hru_data.atol),
+         inspector.field("atolWat", hru_data.atolWat),
+         inspector.field("atolNrg", hru_data.atolNrg),
          inspector.field("forc_stat", hru_data.forc_stat),
          inspector.field("prog_stat", hru_data.prog_stat),
          inspector.field("diag_stat", hru_data.diag_stat),

--- a/build/includes/hru_actor/hru_actor.hpp
+++ b/build/includes/hru_actor/hru_actor.hpp
@@ -44,10 +44,12 @@ extern "C" {
   // hru_writeOutput.f90
   void setFinalizeStatsFalse(int* indx_gru);
 
-  void get_sundials_tolerances(void* hru_data, double* relTol, double* absTol);
-  void set_sundials_tolerances(void* hru_data, double* relTol, double* absTol);
+  void get_steps_tolerances(void* hru_data, int* beSteps, double* rtol, double* atolWat, 
+                               double* atolNrg);
+  void set_steps_tolerances(void* hru_data, int* beSteps, double* rtol, double* atolWat, 
+                               double* atolNrg);
 
-  void setIDATolerances(void* hru_data, double* relTolTempCas, 
+  void setBEStepsIDATol(void* hru_data, int* be_steps, double* relTolTempCas, 
                         double* absTolTempCas, double* relTolTempVeg, 
                         double* absTolTempVeg, double* relTolWatVeg, 
                         double* absTolWatVeg, double* relTolTempSoilSnow,
@@ -96,8 +98,10 @@ struct hru_state {
   std::string err_message;
 
   // Sundials variables
+  int beSteps = -9999; // -9999 uses default
   double rtol = -9999; // -9999 uses default
-  double atol = -9999; // -9999 uses default
+  double atolWat = -9999; // -9999 uses default
+  double atolNrg = -9999; // -9999 uses default
 
   double walltime_timestep = 0.0; // walltime for the current timestep		
 

--- a/build/includes/hru_actor/hru_utils.hpp
+++ b/build/includes/hru_actor/hru_utils.hpp
@@ -16,8 +16,10 @@ struct hru {
   int output_structure_step_index;
 
   // Sundials variables
+  int beSteps;
   double rtol;
-  double atol;
+  double atolWat;
+  double atolNrg;
 
   // HRU data structures
   // Statistic Structure
@@ -76,8 +78,10 @@ bool inspect(Inspector& inspector, hru& hru_data) {
          inspector.field("dt_init_factor", hru_data.dt_init_factor),
          inspector.field("output_structure_step_index", 
                          hru_data.output_structure_step_index),
+         inspector.field("beSteps", hru_data.beSteps),
          inspector.field("rtol", hru_data.rtol),
-         inspector.field("atol", hru_data.atol),
+         inspector.field("atolWat", hru_data.atolWat),
+         inspector.field("atolNrg", hru_data.atolNrg),
          inspector.field("forc_stat", hru_data.forc_stat),
          inspector.field("prog_stat", hru_data.prog_stat),
          inspector.field("diag_stat", hru_data.diag_stat),

--- a/build/includes/job_actor/gru_struc.hpp
+++ b/build/includes/job_actor/gru_struc.hpp
@@ -33,7 +33,8 @@ class GRU {
     // Modifyable Parameters
     int dt_init_factor_;     // The initial dt for the GRU
     double rel_tol_;         // The relative tolerance for the GRU
-    double abs_tol_;         // The absolute tolerance for the GRU
+    double abs_tolWat_;      // The absolute tolerance for the GRU water states
+    double abs_tolNrg_;      // The absolute tolerance for the GRU energy states
 
     // Status Information
     int attempts_left_;      // The number of attempts left for the GRU to succeed
@@ -46,10 +47,10 @@ class GRU {
   public:
     // Constructor
     GRU(int index_netcdf, int index_job, caf::actor actor_ref, 
-        int dt_init_factor, double rel_tol, double abs_tol, int max_attempts) 
+        int dt_init_factor, int be_steps, double rel_tol, double abs_tolWat, double abs_tolNrg, int max_attempts) 
         : index_netcdf_(index_netcdf), index_job_(index_job), 
-          actor_ref_(actor_ref), dt_init_factor_(dt_init_factor),
-          rel_tol_(rel_tol), abs_tol_(abs_tol), attempts_left_(max_attempts),
+          actor_ref_(actor_ref), dt_init_factor_(dt_init_factor), be_steps_(be_steps),
+          rel_tol_(rel_tol), abs_tolWat_(abs_tolWat), abs_tolNrg_(abs_tolNrg), attempts_left_(max_attempts),
           state_(gru_state::running) {};
 
     // Deconstructor
@@ -61,14 +62,17 @@ class GRU {
     inline caf::actor getActorRef() const { return actor_ref_; }
     inline double getRunTime() const { return run_time_; }
     inline double getRelTol() const { return rel_tol_; }
-    inline double getAbsTol() const { return abs_tol_; }
+    inline double getAbsTol() const { return abs_tolWat_; }
+    inline double getAbsTol() const { return abs_tolNrg_; }
     inline int getAttemptsLeft() const { return attempts_left_; }
     inline gru_state getStatus() const { return state_; }
 
     // Setters
     inline void setRunTime(double run_time) { run_time_ = run_time; }
+    inline void setBeSteps(int be_steps) { be_steps_ = be_steps; }
     inline void setRelTol(double rel_tol) { rel_tol_ = rel_tol; }
-    inline void setAbsTol(double abs_tol) { abs_tol_ = abs_tol; }
+    inline void setAbsTol(double abs_tolWat) { abs_tolWat_ = abs_tolWat; }
+    inline void setAbsTol(double abs_tolNrg) { abs_tolNrg_ = abs_tolNrg; }    
     inline void setSuccess() { state_ = gru_state::succeeded; }
     inline void setFailed() { state_ = gru_state::failed; }
     inline void setRunning() { state_ = gru_state::running; }

--- a/build/includes/job_actor/gru_struc.hpp
+++ b/build/includes/job_actor/gru_struc.hpp
@@ -32,6 +32,7 @@ class GRU {
 
     // Modifyable Parameters
     int dt_init_factor_;     // The initial dt for the GRU
+    int be_steps_;           // The number of BE steps for the GRU
     double rel_tol_;         // The relative tolerance for the GRU
     double abs_tolWat_;      // The absolute tolerance for the GRU water states
     double abs_tolNrg_;      // The absolute tolerance for the GRU energy states
@@ -61,9 +62,10 @@ class GRU {
     inline int getIndexJob() const { return index_job_; }
     inline caf::actor getActorRef() const { return actor_ref_; }
     inline double getRunTime() const { return run_time_; }
+    inline int getBeSteps() const { return be_steps_; }
     inline double getRelTol() const { return rel_tol_; }
-    inline double getAbsTol() const { return abs_tolWat_; }
-    inline double getAbsTol() const { return abs_tolNrg_; }
+    inline double getAbsTolWat() const { return abs_tolWat_; }
+    inline double getAbsTolNrg() const { return abs_tolNrg_; }
     inline int getAttemptsLeft() const { return attempts_left_; }
     inline gru_state getStatus() const { return state_; }
 
@@ -71,8 +73,8 @@ class GRU {
     inline void setRunTime(double run_time) { run_time_ = run_time; }
     inline void setBeSteps(int be_steps) { be_steps_ = be_steps; }
     inline void setRelTol(double rel_tol) { rel_tol_ = rel_tol; }
-    inline void setAbsTol(double abs_tolWat) { abs_tolWat_ = abs_tolWat; }
-    inline void setAbsTol(double abs_tolNrg) { abs_tolNrg_ = abs_tolNrg; }    
+    inline void setAbsTolWat(double abs_tolWat) { abs_tolWat_ = abs_tolWat; }
+    inline void setAbsTolNrg(double abs_tolNrg) { abs_tolNrg_ = abs_tolNrg; }    
     inline void setSuccess() { state_ = gru_state::succeeded; }
     inline void setFailed() { state_ = gru_state::failed; }
     inline void setRunning() { state_ = gru_state::running; }

--- a/build/includes/job_actor/job_actor.hpp
+++ b/build/includes/job_actor/job_actor.hpp
@@ -50,6 +50,7 @@ class JobActor {
   HRUActorSettings hru_actor_settings_; 
 
   // HRU Attributes
+  int be_steps_ = -9999;
   double rel_tol_ = -9999;
   double abs_tolWat_ = -9999;
   double abs_tolNrg_ = -9999;

--- a/build/includes/job_actor/job_actor.hpp
+++ b/build/includes/job_actor/job_actor.hpp
@@ -51,7 +51,8 @@ class JobActor {
 
   // HRU Attributes
   double rel_tol_ = -9999;
-  double abs_tol_ = -9999;
+  double abs_tolWat_ = -9999;
+  double abs_tolNrg_ = -9999;
   int dt_init_factor_ = 1;
 
 

--- a/build/source/file_access_actor/summa_init_struc.cpp
+++ b/build/source/file_access_actor/summa_init_struc.cpp
@@ -29,7 +29,7 @@ int SummaInitStruc::summa_readRestart() {
   return err;
 }
 
-void SummaInitStruc::getInitTolerance(double rel_tol, double abs_tol) {
-  f_getInitTolerance(rel_tol, abs_tol);
+void SummaInitStruc::getInitBEStepsIDATol(int be_steps, double rel_tol, double abs_tolWat, double abs_tolNrg) {
+  f_getInitBEStepsIDATol(be_steps, rel_tol, abs_tolWat, abs_tolNrg);
 }
 

--- a/build/source/file_access_actor/summa_init_struc.f90
+++ b/build/source/file_access_actor/summa_init_struc.f90
@@ -238,12 +238,12 @@ subroutine f_getInitBEStepsIDATol(beSteps, rtol, atolWat, atolNrg) &
     atolWat = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absAquifr)%dat(1))/4._rkind
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolAquifr)%dat(1))/4._rkind
     atolNrg = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
   else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
-    beSteps = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1)
+    beSteps = NINT(init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1))
   endif
 #endif
 

--- a/build/source/file_access_actor/summa_init_struc.f90
+++ b/build/source/file_access_actor/summa_init_struc.f90
@@ -243,7 +243,7 @@ subroutine f_getInitBEStepsIDATol(beSteps, rtol, atolWat, atolNrg) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
              + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
   else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
-    beSteps = NINT(init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1))
+    beSteps = NINT(init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_steps)%dat(1))
   endif
 #endif
 

--- a/build/source/file_access_actor/summa_init_struc.f90
+++ b/build/source/file_access_actor/summa_init_struc.f90
@@ -6,7 +6,7 @@ module summa_init_struc
   public :: f_allocate
   public :: f_paramSetup
   public :: f_readRestart
-  public :: f_getInitTolerance 
+  public :: f_getInitBEStepsIDATol 
   public :: f_deallocateInitStruc
   ! Used to get all the inital conditions for the model -- allows calling summa_setup.f90
   type(summa1_type_dec),allocatable,save,public :: init_struc 
@@ -207,26 +207,47 @@ subroutine f_readRestart(err, message_r) bind(C, name="f_readRestart")
 
 end subroutine f_readRestart
 
-subroutine f_getInitTolerance(rtol, atol) &
-    bind(C, name="f_getInitTolerance")
-   USE globalData,only:model_decisions                         ! model decision structure
-  USE var_lookup,only:iLookDECISIONS
-  USE var_lookup,only:iLookPARAM
+subroutine f_getInitBEStepsIDATol(beSteps, rtol, atolWat, atolNrg) &
+    bind(C, name="f_getInitBEStepsIDATol")
+  USE globalData,only:model_decisions                         ! model decision structure
+  USE var_lookup,only:iLookDECISIONS                          ! lookup table for model decisions
+  USE var_lookup,only:iLookPARAM                              ! lookup table for model parameters
   implicit none
   ! dummy variables
+  integer(c_int),       intent(out)       :: beSteps
   real(c_double),       intent(out)       :: rtol 
-  real(c_double),       intent(out)       :: atol
+  real(c_double),       intent(out)       :: atolWat
+  real(c_double),       intent(out)       :: atolNrg
 
+  beSteps = -9999
   rtol = -9999
-  atol = -9999
+  atolWat = -9999
+  atolNrg = -9999
 #ifdef V4_ACTIVE
-  if (model_decisions(iLookDECISIONS%num_method)%iDecision == 83) then
-    rtol = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1)
-    atol = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1)
-  end if
+  if (trim(model_decisions(iLookDECISIONS%num_method)%cDecision)=='ida') then
+    beSteps = 1 ! IDA should have full step size (value isn't used anyhow)
+    ! IDA tolerances, which are set in the model decision file
+    rtol = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempCas)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatVeg)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempVeg)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolMatric)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
+
+    atolWat = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absAquifr)%dat(1))/4._rkind
+    atolNrg = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
+  else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
+    beSteps = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1)
+  endif
 #endif
 
-end subroutine f_getInitTolerance
+end subroutine f_getInitBEStepsIDATol
 
 subroutine f_deallocateInitStruc() bind(C, name="f_deallocateInitStruc")
   USE globalData,only:startTime,finshTime,refTime,oldTime

--- a/build/source/global/logger.cpp
+++ b/build/source/global/logger.cpp
@@ -42,18 +42,18 @@ ErrorLogger::ErrorLogger(const std::string log_dir) {
               + ".csv";
   std::ofstream file;
   file.open(log_file_, std::ios::out);
-  file << "ref_gru,indx_gru,timestep,rel_tol,abs_tol,err_code,err_msg\n";
+  file << "ref_gru,indx_gru,timestep,be_steps,rel_tol,abs_tolWat,abs_tolNrg,err_code,err_msg\n";
   file.close();
 }
 
-void ErrorLogger::logError(int ref_gru, int indx_gru, int timestep, 
-                           double rel_tol, double abs_tol, int err_code, 
+void ErrorLogger::logError(int ref_gru, int indx_gru, int timestep, int be_steps,
+                           double rel_tol, double abs_tolWat, double abs_tolNrg, int err_code, 
                            const std::string &message) {
   if (!enable_logging_) return;
   std::ofstream file;
   file.open(log_file_, std::ios::out | std::ios::app);
-  file << ref_gru << "," << indx_gru << "," << timestep << "," << rel_tol << 
-          "," << abs_tol << "," << err_code << "," << message << "\n";
+  file << ref_gru << "," << indx_gru << "," << timestep << "," << be_steps << "," << rel_tol << 
+          "," << abs_tolWat << "," << abs_tolNrg << "," << err_code << "," << message << "\n";
   file.close();
 }
 
@@ -64,7 +64,7 @@ void ErrorLogger::nextAttempt() {
               + ".csv";
   std::ofstream file;
   file.open(log_file_, std::ios::out);
-    file << "ref_gru,indx_gru,timestep,rel_tol,abs_tol,err_code,err_msg\n";
+    file << "ref_gru,indx_gru,timestep,be_steps,rel_tol,abs_tolWat,abs_tolNrg,err_code,err_msg\n";
   file.close();
 }
 
@@ -84,17 +84,17 @@ SuccessLogger::SuccessLogger(const std::string log_dir) {
               + ".csv";
   std::ofstream file;
   file.open(log_file_, std::ios::out);
-    file << "ref_gru,indx_gru,rel_tol,abs_tol\n";
+    file << "ref_gru,indx_gru,be_steps,rel_tol,abs_tolWat,abs_tolNrg\n";
   file.close();
 }
 
-void SuccessLogger::logSuccess(int ref_gru, int indx_gru, double rel_tol, 
-                               double abs_tol) {
+void SuccessLogger::logSuccess(int ref_gru, int indx_gru, int be_steps, double rel_tol, 
+                               double abs_tolWat, double abs_tolNrg) {
   if (!enable_logging_) return;
   std::ofstream file;
   file.open(log_file_, std::ios::out | std::ios::app);
-    file << ref_gru << "," << indx_gru << "," << rel_tol << 
-            "," << abs_tol << "\n";
+    file << ref_gru << "," << indx_gru << "," << be_steps << "," << rel_tol << 
+            "," << abs_tolWat << "," << abs_tolNrg << "\n";
   file.close();
 }
 
@@ -105,7 +105,7 @@ void SuccessLogger::nextAttempt() {
               + ".csv";
   std::ofstream file;
   file.open(log_file_, std::ios::out);
-    file << "ref_gru,indx_gru,rel_tol,abs_tol\n";
+    file << "ref_gru,indx_gru,be_steps,rel_tol,abs_tolWat,abs_tolNrg\n";
   file.close();
 }
 

--- a/build/source/global/settings_functions.cpp
+++ b/build/source/global/settings_functions.cpp
@@ -63,10 +63,14 @@ int Settings::readSettings() {
         .value_or(true),
     getSettings<int>(json_settings, "HRU_Actor", "output_frequency")
         .value_or(OUTPUT_FREQUENCY),
-    getSettings<double>(json_settings, "HRU_Actor", "abs_tol")
-        .value_or(1e-3),
+    getSettings<double>(json_settings, "HRU_Actor", "abs_tolWat")
+        .value_or(0),
+    getSettings<double>(json_settings, "HRU_Actor", "abs_tolNrg")
+        .value_or(0),
     getSettings<double>(json_settings, "HRU_Actor", "rel_tol")
-        .value_or(1e-3));
+        .value_or(0),
+        getSettings<int>(json_settings, "HRU_Actor", "be_steps")
+        .value_or(0));
 
 
   return SUCCESS;

--- a/build/source/global/settings_functions.cpp
+++ b/build/source/global/settings_functions.cpp
@@ -152,7 +152,7 @@ void Settings::generateConfigFile() {
         {"file_manager_path", "/home/username/summa_file_manager"},
         {"max_run_attempts", 1},
         {"data_assimilation_mode", false},
-        {"batch_size", 10}
+        {"batch_size", 4000}
     };
     config_file["HRU_Actor"] = {
         {"print_output", true},

--- a/build/source/gru_actor/gru_actor.cpp
+++ b/build/source/gru_actor/gru_actor.cpp
@@ -34,7 +34,7 @@ behavior GruActor::make_behavior() {
   }
 
   f_setGruTolerances(gru_data_.get(), hru_actor_settings_.rel_tol_,
-      hru_actor_settings_.abs_tol_);
+      hru_actor_settings_.abs_tolWat_,hru_actor_settings_.abs_tolNrg_);
 
   data_assimilation_mode_ ? self_->become(data_assimilation_mode()) :
                             self_->become(async_mode());

--- a/build/source/gru_actor/gru_actor.cpp
+++ b/build/source/gru_actor/gru_actor.cpp
@@ -33,7 +33,7 @@ behavior GruActor::make_behavior() {
     return {};
   }
 
-  f_setGruTolerances(gru_data_.get(), hru_actor_settings_.rel_tol_,
+  f_setGruTolerances(gru_data_.get(),hru_actor_settings_.be_steps_,hru_actor_settings_.rel_tol_,
       hru_actor_settings_.abs_tolWat_,hru_actor_settings_.abs_tolNrg_);
 
   data_assimilation_mode_ ? self_->become(data_assimilation_mode()) :

--- a/build/source/gru_actor/gru_actor.f90
+++ b/build/source/gru_actor/gru_actor.f90
@@ -32,14 +32,16 @@ subroutine f_getNumHruInGru(indx_gru, num_hru) bind(C, name="f_getNumHruInGru")
   num_hru = gru_struc(indx_gru)%hruCount
 end subroutine f_getNumHruInGru
 
-subroutine f_setGruTolerances(handle_gru_data, rel_tol, abs_tol) bind(C, name="f_setGruTolerances")
+subroutine f_setGruTolerances(handle_gru_data, be_steps, rel_tol, abs_tolWat, abs_tolNrg) bind(C, name="f_setGruTolerances")
   USE actor_data_types,only:gru_type
   USE var_lookup,only: iLookPARAM
 
   implicit none
   type(c_ptr), intent(in),value :: handle_gru_data
+  real(c_int), intent(in)       :: be_steps
   real(c_double), intent(in)    :: rel_tol
-  real(c_double), intent(in)    :: abs_tol
+  real(c_double), intent(in)    :: abs_tolWat
+  real(c_double), intent(in)    :: abs_tolNrg
   ! Local Varaibles
   integer(i4b)                  :: iHRU
 
@@ -47,30 +49,27 @@ subroutine f_setGruTolerances(handle_gru_data, rel_tol, abs_tol) bind(C, name="f
   call c_f_pointer(handle_gru_data, gru_data)
 
   do iHRU = 1, size(gru_data%hru)
-    ! Set rtols
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relConvTol_liquid)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relConvTol_matric)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relConvTol_energy)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relConvTol_aquifr)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolWatVeg)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempSoilSnow)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolWatSnow)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolMatric)%dat(1) = rel_tol
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolAquifr)%dat(1) = rel_tol
-  
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absConvTol_liquid)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absConvTol_matric)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absConvTol_energy)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absConvTol_aquifr)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempVeg)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolWatVeg)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempSoilSnow)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolMatric)%dat(1) = abs_tol 
-    gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1) = abs_tol 
+    ! Reset only if the values are valid
+    if (rel_tol > 0.0 .and. abs_tolWat > 0.0 .and. abs_tolNrg > 0.0 ) then
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolWatVeg)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolTempSoilSnow)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolWatSnow)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolMatric)%dat(1) = rel_tol
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%relTolAquifr)%dat(1) = rel_tol
+
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1) = abs_tolNrg
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempVeg)%dat(1) = abs_tolNrg 
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolWatVeg)%dat(1) = abs_tolWat 
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolTempSoilSnow)%dat(1) = abs_tolNrg 
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1) = abs_tolWat 
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolMatric)%dat(1) = abs_tolWat 
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1) = abs_tolWat 
+    end if
+    if (be_steps>0) then
+      gru_data%hru(iHRU)%mparStruct%var(iLookPARAM%be_steps)%dat(1) = be_steps
+    end if
   end do
 
 

--- a/build/source/gru_actor/gru_actor.f90
+++ b/build/source/gru_actor/gru_actor.f90
@@ -38,7 +38,7 @@ subroutine f_setGruTolerances(handle_gru_data, be_steps, rel_tol, abs_tolWat, ab
 
   implicit none
   type(c_ptr), intent(in),value :: handle_gru_data
-  real(c_int), intent(in)       :: be_steps
+  integer(c_int), intent(in)    :: be_steps
   real(c_double), intent(in)    :: rel_tol
   real(c_double), intent(in)    :: abs_tolWat
   real(c_double), intent(in)    :: abs_tolNrg

--- a/build/source/gru_actor/hru_init.f90
+++ b/build/source/gru_actor/hru_init.f90
@@ -412,7 +412,8 @@ subroutine readHRURestart(indxGRU, indxHRU, hru_data, err, message)
 end subroutine readHRURestart
 
 ! Set the HRU's relative and absolute tolerances
-subroutine setIDATolerances(handle_hru_data,    &
+subroutine setBEStepsIDATol(handle_hru_data,    &
+                            be_steps,           &
                             relTolTempCas,      &
                             absTolTempCas,      &
                             relTolTempVeg,      &
@@ -426,13 +427,14 @@ subroutine setIDATolerances(handle_hru_data,    &
                             relTolMatric,       &
                             absTolMatric,       &
                             relTolAquifr,       &
-                            absTolAquifr) bind(C, name="setIDATolerances")
+                            absTolAquifr) bind(C, name="setBEStepsIDATol")
   USE data_types,only:var_dlength
   USE var_lookup,only:iLookPARAM
 
   implicit none
 
   type(c_ptr), intent(in), value          :: handle_hru_data    !  model time data
+  real(int),intent(in)                    :: be_steps
   real(c_double),intent(in)               :: relTolTempCas
   real(c_double),intent(in)               :: absTolTempCas
   real(c_double),intent(in)               :: relTolTempVeg
@@ -452,7 +454,8 @@ subroutine setIDATolerances(handle_hru_data,    &
 
   call c_f_pointer(handle_hru_data, hru_data)
 
-#ifdef SUNDIALS_ACTIVE
+#ifdef V4_ACTIVE
+  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1)            = be_steps
   hru_data%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1)       = relTolTempCas 
   hru_data%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1)       = absTolTempCas
   hru_data%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1)       = relTolTempVeg
@@ -468,5 +471,5 @@ subroutine setIDATolerances(handle_hru_data,    &
   hru_data%mparStruct%var(iLookPARAM%relTolAquifr)%dat(1)        = relTolAquifr
   hru_data%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1)        = absTolAquifr
 #endif
-end subroutine setIDATolerances
+end subroutine setBEStepsIDATol
 end module INIT_HRU_ACTOR

--- a/build/source/gru_actor/hru_init.f90
+++ b/build/source/gru_actor/hru_init.f90
@@ -434,7 +434,7 @@ subroutine setBEStepsIDATol(handle_hru_data,    &
   implicit none
 
   type(c_ptr), intent(in), value          :: handle_hru_data    !  model time data
-  real(int),intent(in)                    :: be_steps
+  integer(c_int),intent(in)               :: be_steps
   real(c_double),intent(in)               :: relTolTempCas
   real(c_double),intent(in)               :: absTolTempCas
   real(c_double),intent(in)               :: relTolTempVeg

--- a/build/source/gru_actor/hru_init.f90
+++ b/build/source/gru_actor/hru_init.f90
@@ -455,7 +455,7 @@ subroutine setBEStepsIDATol(handle_hru_data,    &
   call c_f_pointer(handle_hru_data, hru_data)
 
 #ifdef V4_ACTIVE
-  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1)            = be_steps
+  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1)            = REAL(be_steps)
   hru_data%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1)       = relTolTempCas 
   hru_data%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1)       = absTolTempCas
   hru_data%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1)       = relTolTempVeg

--- a/build/source/gru_actor/hru_modelRun.f90
+++ b/build/source/gru_actor/hru_modelRun.f90
@@ -68,9 +68,9 @@ USE mDecisions_module,only:&               ! look-up values for LAI decisions
 implicit none
 private
 public::runPhysics
-#ifdef SUNDIALS_ACTIVE
-public::get_sundials_tolerances
-public::set_sundials_tolerances
+#ifdef V4_ACTIVE
+public::get_steps_tolerances
+public::set_steps_tolerances
 #endif
 contains
 
@@ -263,47 +263,72 @@ subroutine runPhysics(indxGRU, indxHRU, modelTimeStep, hru_data, &
 end subroutine runPhysics
 
 ! *******************************************************************************************
-! *** get_sundials_tolerances
+! *** get_steps_tolerances
 ! *******************************************************************************************
-#ifdef SUNDIALS_ACTIVE
-subroutine get_sundials_tolerances(handle_hru_data, rtol, atol) bind(C, name='get_sundials_tolerances')
-  USE var_lookup,only: iLookPARAM
+#ifdef V4_ACTIVE
+subroutine get_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg) bind(C, name='get_steps_tolerances')
+  USE globalData,only:model_decisions                         ! model decision structure
+  USE var_lookup,only:iLookDECISIONS                          ! look-up values for model decisions
+  USE var_lookup,only:iLookPARAM                              ! look-up values for local column model parameters
   implicit none
 
   ! dummy variables
   type(c_ptr),    intent(in), value         :: handle_hru_data        ! c_ptr to -- hru data
+  real(c_int),    intent(out)               :: beSteps                ! number of backward Euler steps in data window
   real(c_double), intent(out)               :: rtol                   ! relative tolerance
-  real(c_double), intent(out)               :: atol                   ! absolute tolerance
+  real(c_double), intent(out)               :: atolWat                ! absolute tolerance for water states
+  real(c_double), intent(out)               :: atolNrg                ! absolute tolerance for energy states
   ! local variables
   type(hru_type),pointer                    :: hru_data               ! hru data
   call c_f_pointer(handle_hru_data, hru_data)
 
-  ! get tolerances
-  rtol = hru_data%mparStruct%var(iLookPARAM%relTolWatSnow)%dat(1) 
-  atol = hru_data%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1)
-end subroutine get_sundials_tolerances
+  if (trim(model_decisions(iLookDECISIONS%num_method)%cDecision)=='ida') then
+    beSteps = 1 ! IDA should have full step size (value isn't used anyhow)
+    ! IDA tolerances, which are set in the model decision file
+    rtol = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempCas)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatVeg)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempVeg)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolMatric)%dat(1) &
+          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
+
+    atolWat = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absAquifr)%dat(1))/4._rkind
+    atolNrg = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
+             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
+  else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
+    beSteps = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1)
+    rtol = -9999    ! BE doesn't use these
+    atolWat = -9999
+    atolNrg = -9999
+  endif
+end subroutine get_steps_tolerances
 
 ! *******************************************************************************************
-! *** get_sundials_tolerances
+! *** get_steps_tolerances
 ! *******************************************************************************************
-subroutine set_sundials_tolerances(handle_hru_data, rtol, atol) bind(C, name='set_sundials_tolerances')
-  USE var_lookup,only: iLookPARAM
+subroutine set_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg) bind(C, name='set_steps_tolerances')
+  USE var_lookup,only:iLookPARAM                              ! look-up values for local column model parameters
   implicit none
 
   ! dummy variables
-  type(c_ptr),    intent(in), value         :: handle_hru_data        ! c_ptr to -- hru data
+  type(c_ptr), intent(in), value           :: handle_hru_data        ! c_ptr to -- hru data
+  real(c_int), intent(in)                  :: beSteps                ! number of backward Euler steps in data window
   real(c_double), intent(in)               :: rtol                   ! relative tolerance
-  real(c_double), intent(in)               :: atol                   ! absolute tolerance
+  real(c_double), intent(in)               :: atolWat                ! absolute tolerance for water
+  real(c_double), intent(in)               :: atolNrg                ! absolute tolerance for energy
+
   ! local variables
-  type(hru_type),pointer                    :: hru_data               ! hru data
+  type(hru_type),pointer                    :: hru_data              ! hru data
   call c_f_pointer(handle_hru_data, hru_data)
 
-
+  ! set beSteps
+  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1) = beSteps
   ! Set rtols
-  hru_data%mparStruct%var(iLookPARAM%relConvTol_liquid)%dat(1) = rtol  
-  hru_data%mparStruct%var(iLookPARAM%relConvTol_matric)%dat(1) = rtol  
-  hru_data%mparStruct%var(iLookPARAM%relConvTol_energy)%dat(1) = rtol  
-  hru_data%mparStruct%var(iLookPARAM%relConvTol_aquifr)%dat(1) = rtol  
   hru_data%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1) = rtol  
   hru_data%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1) = rtol  
   hru_data%mparStruct%var(iLookPARAM%relTolWatVeg)%dat(1) = rtol  
@@ -312,18 +337,15 @@ subroutine set_sundials_tolerances(handle_hru_data, rtol, atol) bind(C, name='se
   hru_data%mparStruct%var(iLookPARAM%relTolMatric)%dat(1) = rtol  
   hru_data%mparStruct%var(iLookPARAM%relTolAquifr)%dat(1) = rtol  
   ! Set atols
-  hru_data%mparStruct%var(iLookPARAM%absConvTol_liquid)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absConvTol_matric)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absConvTol_energy)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absConvTol_aquifr)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolTempVeg)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolWatVeg)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolTempSoilSnow)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolMatric)%dat(1) = atol 
-  hru_data%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1) = atol 
-end subroutine set_sundials_tolerances
+  hru_data%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1) = atolNrg
+  hru_data%mparStruct%var(iLookPARAM%absTolTempVeg)%dat(1) = atolNrg 
+  hru_data%mparStruct%var(iLookPARAM%absTolWatVeg)%dat(1) = atolWat
+  hru_data%mparStruct%var(iLookPARAM%absTolTempSoilSnow)%dat(1) = atolNrg
+  hru_data%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1) = atolWat 
+  hru_data%mparStruct%var(iLookPARAM%absTolMatric)%dat(1) = atolWat
+  hru_data%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1) = atolWat
+
+end subroutine set_steps_tolerances
 #endif
 
 end module summa_modelRun

--- a/build/source/gru_actor/hru_modelRun.f90
+++ b/build/source/gru_actor/hru_modelRun.f90
@@ -274,7 +274,7 @@ subroutine get_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg
 
   ! dummy variables
   type(c_ptr),    intent(in), value         :: handle_hru_data        ! c_ptr to -- hru data
-  real(c_int),    intent(out)               :: beSteps                ! number of backward Euler steps in data window
+  integer(c_int), intent(out)               :: beSteps                ! number of backward Euler steps in data window
   real(c_double), intent(out)               :: rtol                   ! relative tolerance
   real(c_double), intent(out)               :: atolWat                ! absolute tolerance for water states
   real(c_double), intent(out)               :: atolNrg                ! absolute tolerance for energy states
@@ -285,23 +285,23 @@ subroutine get_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg
   if (trim(model_decisions(iLookDECISIONS%num_method)%cDecision)=='ida') then
     beSteps = 1 ! IDA should have full step size (value isn't used anyhow)
     ! IDA tolerances, which are set in the model decision file
-    rtol = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempCas)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatVeg)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempVeg)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolMatric)%dat(1) &
-          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
+    rtol = (hru_data%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolWatVeg)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolWatSnow)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolMatric)%dat(1) &
+          + hru_data%mparStruct%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
 
-    atolWat = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
-             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
-             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
-             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolAquifr)%dat(1))/4._rkind
-    atolNrg = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
-             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
-             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
+    atolWat = (hru_data%mparStruct%var(iLookPARAM%absTolWatVeg)%dat(1) &
+             + hru_data%mparStruct%var(iLookPARAM%absTolWatSnow)%dat(1) &
+             + hru_data%mparStruct%var(iLookPARAM%absTolMatric)%dat(1) &
+             + hru_data%mparStruct%var(iLookPARAM%absTolAquifr)%dat(1))/4._rkind
+    atolNrg = (hru_data%mparStruct%var(iLookPARAM%absTolTempCas)%dat(1) &
+             + hru_data%mparStruct%var(iLookPARAM%absTolTempVeg)%dat(1) &
+             + hru_data%mparStruct%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
   else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
-    beSteps = NINT(hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1))
+    beSteps = NINT(hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1))
     rtol = -9999    ! BE doesn't use these
     atolWat = -9999
     atolNrg = -9999
@@ -317,7 +317,7 @@ subroutine set_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg
 
   ! dummy variables
   type(c_ptr), intent(in), value           :: handle_hru_data        ! c_ptr to -- hru data
-  real(c_int), intent(in)                  :: beSteps                ! number of backward Euler steps in data window
+  integer(c_int), intent(in)               :: beSteps                ! number of backward Euler steps in data window
   real(c_double), intent(in)               :: rtol                   ! relative tolerance
   real(c_double), intent(in)               :: atolWat                ! absolute tolerance for water
   real(c_double), intent(in)               :: atolNrg                ! absolute tolerance for energy

--- a/build/source/gru_actor/hru_modelRun.f90
+++ b/build/source/gru_actor/hru_modelRun.f90
@@ -21,7 +21,7 @@
 module summa_modelRun
 ! calls the model physics
 USE,intrinsic :: iso_c_binding
-
+USE nrtype
 USE actor_data_types,only:hru_type
 ! access missing values
 USE globalData,only:integerMissing         ! missing integer

--- a/build/source/gru_actor/hru_modelRun.f90
+++ b/build/source/gru_actor/hru_modelRun.f90
@@ -285,23 +285,23 @@ subroutine get_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg
   if (trim(model_decisions(iLookDECISIONS%num_method)%cDecision)=='ida') then
     beSteps = 1 ! IDA should have full step size (value isn't used anyhow)
     ! IDA tolerances, which are set in the model decision file
-    rtol = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempCas)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatVeg)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempVeg)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolMatric)%dat(1) &
-          + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
+    rtol = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempCas)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatVeg)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempVeg)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolWatSnow)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolTempSoilSnow)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolMatric)%dat(1) &
+          + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%relTolAquifr)%dat(1))/7._rkind
 
-    atolWat = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absAquifr)%dat(1))/4._rkind
-    atolNrg = (init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
-             + init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
+    atolWat = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatVeg)%dat(1) &
+             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolWatSnow)%dat(1) &
+             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolMatric)%dat(1) &
+             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolAquifr)%dat(1))/4._rkind
+    atolNrg = (hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempCas)%dat(1) &
+             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempVeg)%dat(1) &
+             + hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%absTolTempSoilSnow)%dat(1))/3._rkind
   else ! all other methods are currently BE -- 'homegrown' ('itertive'), 'kinsol'
-    beSteps = init_struc%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1)
+    beSteps = NINT(hru_data%mparStruct%gru(1)%hru(1)%var(iLookPARAM%be_stepss)%dat(1))
     rtol = -9999    ! BE doesn't use these
     atolWat = -9999
     atolNrg = -9999
@@ -327,7 +327,7 @@ subroutine set_steps_tolerances(handle_hru_data, beSteps, rtol, atolWat, atolNrg
   call c_f_pointer(handle_hru_data, hru_data)
 
   ! set beSteps
-  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1) = beSteps
+  hru_data%mparStruct%var(iLookPARAM%be_steps)%dat(1) = REAL(beSteps)
   ! Set rtols
   hru_data%mparStruct%var(iLookPARAM%relTolTempCas)%dat(1) = rtol  
   hru_data%mparStruct%var(iLookPARAM%relTolTempVeg)%dat(1) = rtol  

--- a/build/source/hru_actor/hru_actor.cpp
+++ b/build/source/hru_actor/hru_actor.cpp
@@ -224,12 +224,16 @@ int initHRU(stateful_actor<hru_state>* self) {
     self->state.err_message = message.get();
     return err;
   }
-  #ifdef SUNDIALS_ACTIVE
-    if (self->state.hru_actor_settings.rel_tol > 0 && 
-        self->state.hru_actor_settings.abs_tol > 0) {
-      set_sundials_tolerances(self->state.hru_data, 
+  #ifdef V4_ACTIVE
+    if (self->state.hru_actor_settings.be_steps > 0 &&
+        self->state.hru_actor_settings.rel_tol > 0 && 
+        self->state.hru_actor_settings.abs_tolWat > 0 &&
+        self->state.hru_actor_settings.abs_tolNrg > 0) {
+      set_steps_tolerances(self->state.hru_data, 
+          &self->state.hru_actor_settings.be_steps,
           &self->state.hru_actor_settings.rel_tol, 
-          self->state.hru_actor_settings.abs_tol);
+          &self->state.hru_actor_settings.abs_tolWat,
+          self->state.hru_actor_settings.abs_tolNrg);
     }
   #endif     
   

--- a/build/source/hru_actor/hru_utils.cpp
+++ b/build/source/hru_actor/hru_utils.cpp
@@ -19,8 +19,10 @@ void serializeHru(stateful_actor<hru_state>* self, hru& serialized_state) {
   serialized_state.dt_init_factor = self->state.dt_init_factor;
   serialized_state.output_structure_step_index = 
       self->state.output_structure_step_index; 
+  serialized_state.beSteps = self->state.beSteps;
   serialized_state.rtol = self->state.rtol;
-  serialized_state.atol = self->state.atol;
+  serialized_state.atolWat = self->state.atolWat;
+  serialized_state.atolNrg = self->state.atolNrg;
 
   // Statistic Structures
   serialized_state.forc_stat = get_var_dlength_by_indx(self->state.hru_data, 1); 
@@ -89,8 +91,10 @@ void deserializeHru(stateful_actor<hru_state>* self, hru& new_state) {
   self->state.dt_init_factor = new_state.dt_init_factor;
   self->state.output_structure_step_index = 
       new_state.output_structure_step_index;
+  self->state.beSteps = new_state.beSteps;
   self->state.rtol = new_state.rtol;
-  self->state.atol = new_state.atol;
+  self->state.atolWat = new_state.atolWat;
+  self->state.atolNrg = new_state.atolNrg;
   // Statistic Structures
   set_var_dlength_by_indx(self->state.hru_data, new_state.forc_stat, 1);
   set_var_dlength_by_indx(self->state.hru_data, new_state.prog_stat, 2);

--- a/build/source/job_actor/da_client_actor.cpp
+++ b/build/source/job_actor/da_client_actor.cpp
@@ -218,7 +218,7 @@ void DAClientActor::spawnGruBatches() {
         settings_.fa_actor_settings_.num_timesteps_in_output_buffer_, 
         file_access_actor_, self_);
     std::unique_ptr<GRU> gru_obj = std::make_unique<GRU>(
-        start_hru_global, start_hru_local, gru_batch, 1, 1.0e-10, 1.0e-10,
+        start_hru_global, start_hru_local, gru_batch, 1, 1, 1.0e-10, 1.0e-10, 1.0e-10,
         settings_.job_actor_settings_.max_run_attempts_);
     gru_struc_->addGRU(std::move(gru_obj));
     remaining_hru_to_batch -= current_batch_size;

--- a/build/source/job_actor/da_client_actor.cpp
+++ b/build/source/job_actor/da_client_actor.cpp
@@ -85,7 +85,7 @@ behavior DAClientActor::make_behavior() {
         self_->quit();
         return;
       }
-      // summa_init_struc_->getInitTolerance(rel_tol_, abs_tol_);
+      // summa_init_struc_->getInitBEStepsIDATol(be_steps_, rel_tol_, abs_tolWat_, abs_tolNrg_);
 
       NumGRUInfo num_gru_info = NumGRUInfo(
           node_gru_info.node_start_gru_, node_gru_info.node_start_gru_,

--- a/build/source/job_actor/job_actor.cpp
+++ b/build/source/job_actor/job_actor.cpp
@@ -62,7 +62,7 @@ behavior JobActor::make_behavior() {
     self_->mail(err_atom_v, -2, err_msg).send(parent_);
     return {};
   }
-  summa_init_struc_->getInitTolerance(rel_tol_, abs_tol_);
+  summa_init_struc_->getInitBEStepsIDATol(be_steps_, rel_tol_, abs_tolWat_, abs_tolNrg_);
   
   num_gru_info_ = NumGRUInfo(batch_.getStartHRU(), batch_.getStartHRU(), 
                              batch_.getNumHRU(), batch_.getNumHRU(), 
@@ -120,14 +120,27 @@ behavior JobActor::async_mode() {
     },
 
     [this](restart_failures) {
-      logger_->log("Async Mode: Restarting Failed GRUs");
-      self_->println("Async Mode: Restarting Failed GRUs\n");
-      if (rel_tol_ > 0 && abs_tol_ > 0) {
+      logger_->log("Async Mode: Restarting Failed GRUs (only works for >=V4)");
+      self_->println("Async Mode: Restarting Failed GRUs (only works for >=V4)\n");
+      if (rel_tol_ > 0 && abs_tolWat_ > 0 && abs_tolNrg_ > 0) {
+        logger_->log("Reducing IDA Tolerances by * 0.1");
+        self_->println("Reducing IDA Tolerances by * 0.1\n");
         rel_tol_ /= 10;
         hru_actor_settings_.rel_tol_ = rel_tol_;
-        abs_tol_ /= 10;
-        hru_actor_settings_.abs_tol_ = abs_tol_;
+        abs_tolWat_ /= 10;
+        hru_actor_settings_.abs_tolWat_ = abs_tolWat_;
+        abs_tolNrg_ /= 10;
+        hru_actor_settings_.abs_tolNrg_ = abs_tolNrg_;
+        be_steps_ = 1;
+        hru_actor_settings_.be_steps = be_steps_;
+      } else if (be_steps_ >0) {
+        logger_->log("Increasing BE Steps by * 2");
+        self_->println("Increasing BE Steps by * 2\n");
+        be_steps_ *= 2;
+        hru_actor_settings_.be_steps = be_steps_;
       } else {
+        logger_->log("Initial IDA Tolerances and BE Steps not set, increasing dt_init_factor by * 2 (not recommended)");
+        self_->println("Initial IDA Tolerances and BE Steps not set, increasing dt_init_factor by * 2 (not recommended)\n");
         dt_init_factor_ *= 2;
       }
 
@@ -156,7 +169,7 @@ behavior JobActor::async_mode() {
         gru_struc_->decrementNumGruFailed();
         std::unique_ptr<GRU> gru_obj = std::make_unique<GRU>(
             netcdf_index, job_index, gru_actor, dt_init_factor_, rel_tol_, 
-            abs_tol_, job_actor_settings_.max_run_attempts_);
+            abs_tolWat_, abs_tolNrg_, job_actor_settings_.max_run_attempts_);
         gru_struc_->addGRU(std::move(gru_obj));
         self_->mail(update_hru_async_v).send(gru_actor);
       }
@@ -293,9 +306,14 @@ void JobActor::spawnGruActors() {
     rel_tol_ = hru_actor_settings_.rel_tol_;
   }
 
-  if (hru_actor_settings_.abs_tol_ > 0) {
+  if (hru_actor_settings_.abs_tolWat_ > 0) {
     // f_getAbsTol();
-    abs_tol_ = hru_actor_settings_.abs_tol_;
+    abs_tolWat_ = hru_actor_settings_.abs_tolWat_;
+  }
+
+  if (hru_actor_settings_.abs_tolNrg_ > 0) {
+    // f_getAbsTol();
+    abs_tolNrg_ = hru_actor_settings_.abs_tolNrg_;
   }
 
   for (int i = 0; i < gru_struc_->getNumGru(); i++) {
@@ -308,7 +326,7 @@ void JobActor::spawnGruActors() {
         self_);
     std::unique_ptr<GRU> gru_obj = std::make_unique<GRU>(
         netcdf_index, job_index, gru_actor, dt_init_factor_, rel_tol_, 
-        abs_tol_, job_actor_settings_.max_run_attempts_);
+        abs_tolWat_, abs_tolNrg_, job_actor_settings_.max_run_attempts_);
     gru_struc_->addGRU(std::move(gru_obj));
     
     if (!job_actor_settings_.data_assimilation_mode_) {
@@ -328,15 +346,20 @@ void JobActor::spawnGruBatches() {
     rel_tol_ = hru_actor_settings_.rel_tol_;
   }
 
-  if (hru_actor_settings_.abs_tol_ <= 0) {
+  if (hru_actor_settings_.abs_tolWat_ <= 0) {
     // f_getAbsTol();
-    abs_tol_ = hru_actor_settings_.abs_tol_;
+    abs_tolWat_ = hru_actor_settings_.abs_tolWat_;
+  }
+
+  if (hru_actor_settings_.abs_tolNrg_ <= 0) {
+    // f_getAbsTol();
+    abs_tolNrg_ = hru_actor_settings_.abs_tolNrg_;
   }
 
   // if (rel_tol_ <= 0) {
   // }
 
-  // if (abs_tol_ <= 0) {
+  // if (abs_tolWat_ <= 0) {
   //   f_getAbsTol();
   // }
 
@@ -369,7 +392,7 @@ void JobActor::spawnGruBatches() {
 
     std::unique_ptr<GRU> gru_obj = std::make_unique<GRU>(
         netcdf_start_index, job_start_index, gru_batch, dt_init_factor_, 
-        rel_tol_, abs_tol_, job_actor_settings_.max_run_attempts_);
+        rel_tol_, abs_tolWat_, abs_tolNrg_, job_actor_settings_.max_run_attempts_);
     gru_struc_->addGRU(std::move(gru_obj));
     remaining_hru_to_batch -= current_batch_size;
     job_start_index += current_batch_size;
@@ -402,7 +425,7 @@ void JobActor::handleFinishedGRU(int job_index) {
   gru_struc_->getGRU(job_index)->setSuccess();
   success_logger_->logSuccess(gru_struc_->getGRU(job_index)->getIndexNetcdf(),
                               gru_struc_->getGRU(job_index)->getIndexJob(),
-                              rel_tol_, abs_tol_);
+                              rel_tol_, abs_tolWat_, abs_tolNrg_);
   std::string update_str =
       "GRU Finished: " + std::to_string(gru_struc_->getNumGruDone()) + "/" + 
       std::to_string(gru_struc_->getNumGru()) + " -- GlobalGRU=" + 


### PR DESCRIPTION
The variables 
```
"HRU_Actor": {
    "print_output": true,
    "output_frequency": 1000,
    "rel_tol": 0.00001,
    "abs_tolWat": 0.00001,
    "abs_tolNrg": 0.001,
    "be_steps":8
```
can now be changed in the json, where the last 3 have been added. On failure if "JobActor":"max_run_attempts" was set to more than 1 in the json, a restart will happen with the tol variables being *0.1 and be_steps being *2. The be_steps is the number of data steps in a BE solver data window, and the tol variables control an IDA run. (Currently, runs are either solved with a BE solver or IDA). dt_init_factor is no longer increased in a restart, unless the tolerances are not set for an IDA run or be_steps is not set for a BE run. 

Other minor changes -- sundials build is suggested to be compiled at Release, paths are changed to $HOME instead of Kyle's directory, and the example json written does not suggest batch =10 (Kyle says this is too small). 